### PR TITLE
Update Prometheus.Client.MetricServer.csproj

### DIFF
--- a/src/Prometheus.Client.MetricServer/Prometheus.Client.MetricServer.csproj
+++ b/src/Prometheus.Client.MetricServer/Prometheus.Client.MetricServer.csproj
@@ -11,10 +11,10 @@
     <PackageId>Prometheus.Client.MetricServer</PackageId>
     <PackageTags>prometheus;metrics</PackageTags>
     <PackageIconUrl>https://image.ibb.co/k4Sc0k/prometheus.png</PackageIconUrl>
-    <PackageProjectUrl>https://github.com/PrometheusClientNet/Prometheus.MetricServer</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/PrometheusClientNet/Prometheus.Client.MetricServer</PackageProjectUrl>
     <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/PrometheusClientNet/Prometheus.MetricServer</RepositoryUrl>
+    <RepositoryUrl>https://github.com/PrometheusClientNet/Prometheus.Client.MetricServer/RepositoryUrl>
     <PackageReleaseNotes>https://github.com/PrometheusClientNet/Prometheus.Client.MetricServer/releases</PackageReleaseNotes>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Fix the project URLs, so that the NuGet listing has the correct website.