### PR TITLE
WIP: Moved HttpListener Start into background thread

### DIFF
--- a/src/Prometheus.Client.MetricServer/MetricServer.HttpListener.cs
+++ b/src/Prometheus.Client.MetricServer/MetricServer.HttpListener.cs
@@ -48,7 +48,6 @@ namespace Prometheus.Client.MetricServer
             if (_httpListener.IsListening)
                 return;
 
-            _httpListener.Start();
             var bgThread = new Thread(StartListen)
             {
                 IsBackground = true,
@@ -70,6 +69,8 @@ namespace Prometheus.Client.MetricServer
 
         private void StartListen()
         {
+            _httpListener.Start();            
+
             var cancel = _cancellation.Token;
 
             while (!_cancellation.IsCancellationRequested)


### PR DESCRIPTION
came across a security issue with starting the HttpListener in the foreground thread.

Creating a build to see if this fixes the Issue